### PR TITLE
Reverse elevation in track structure

### DIFF
--- a/editor/static/editor/editor.js
+++ b/editor/static/editor/editor.js
@@ -334,7 +334,7 @@ function reverse_segment() {
             method: 'POST',
         }).then( response => {
             if (response.status === 200) {
-                reverse_utils.reverse_elevation(chart, selected_segment.idx);
+                reverse_utils.reverse_elevation(track, chart, selected_segment.idx);
                 reverse_utils.reverse_map_link(map, track, selected_segment.idx);
                 reverse_utils.reverse_elevation_link(chart, track, selected_segment.idx);
                 utils.deactivate_spinner('#div_spinner');

--- a/editor/static/editor/reverse.js
+++ b/editor/static/editor/reverse.js
@@ -2,15 +2,21 @@ import * as plot from "./plot.js";
 import * as utils from "./utils.js";
 
 
-export function reverse_elevation(chart, segment_index) {
+export function reverse_elevation(track, chart, segment_index) {
     chart.data.datasets.forEach(dataset => {
         if (dataset.label === `elevation_${segment_index}`) {
             let reversed_data = [];
             let size = dataset.data.length;
-            for (let i = 0; i < size; i++){
+            for (let i = 0; i < size; i++){  // reverse elevation in plot
                 reversed_data.push({x: dataset.data[i].x, y: dataset.data[size - i - 1].y});
             }
             dataset.data = reversed_data;
+
+            for (let segment of track['segments']) {  // reverse elevation in track
+                if (segment['index'] === segment_index) {
+                    segment['ele'].reverse();
+                }
+            }
         }
     });
     chart.update();


### PR DESCRIPTION
## Scope
Elevation is not reversed in the track structure of editor.js. This is provoking bug #114  
Since no unittest on JS are created, this is tested manually. Testing will be a visual check of the bug correction.

## Tasks
- [x] Insert the segment elevation reverse in JS  
- [x] Manual test