### PR TITLE
Bugs correction on splitting segment related operations

### DIFF
--- a/editor/static/editor/data_operations.js
+++ b/editor/static/editor/data_operations.js
@@ -12,6 +12,8 @@ export function submit_file() {
 export async function load_track() {
     try {
         const response = await fetch('/editor/get_track');
+        utils.response_error_mng(response.status, 'load_track');
+
         return await response.json();
     } catch (error) {
         utils.display_error('error', error);

--- a/editor/static/editor/editor.js
+++ b/editor/static/editor/editor.js
@@ -147,8 +147,11 @@ function remove_segment(segment_index, list) {
         if (response.status !== 201) {
             throw new Error(`Server error by ${response.status} when removing segment.`);
         }
-    }).then(() =>
-        update_distance()
+    }).then ( () => {
+        track.segments = track.segments.sort((first, second) => {
+            return first['index'] - second['index'];
+        });
+    }).then(() => update_distance()
     ).then(() => {
         // Remove elevation plots and links
         chart.data.datasets = [];
@@ -567,6 +570,9 @@ function update_distance() {
      * is removed or order is changed. So, it is needed to update it without
      * the need of an API call.
      * */
+    track['segments'][0]['segment_distance'] =
+        track['segments'][0]['segment_distance'].map(a =>
+            a - track['segments'][0]['segment_distance'][0]);
     track['segments'][0]['distance'] = track['segments'][0]['segment_distance'];
 
     for (let i = 1; i < track['segments'].length; i++) {

--- a/editor/static/editor/plot.js
+++ b/editor/static/editor/plot.js
@@ -39,7 +39,7 @@ export function create_map() {
         view: new ol.View({
             center: ol.proj.fromLonLat([0, 0]),
             zoom: 1,
-            maxZoom: 16,
+            maxZoom: 20,
             minZoom: 1
         }),
         layers: [
@@ -203,6 +203,7 @@ export function get_lines_style(color_index, alpha) {
 export function plot_elevation(chart, segment) {
     // Plot elevation
     let elevation_data = [];
+
     segment.distance.forEach((distance, index) => {
         let elevation = segment.ele[index];
         elevation_data.push({x: distance, y: elevation});

--- a/editor/static/editor/split_segment.js
+++ b/editor/static/editor/split_segment.js
@@ -155,7 +155,6 @@ function remove_map_point(map) {
 }
 
 export function execute_split(track, segment_index, split_point) {
-    console.log(track);
     // Update index of later segments
     track.segments.forEach(seg => {
         if (seg.index > segment_index) {
@@ -165,12 +164,13 @@ export function execute_split(track, segment_index, split_point) {
 
     // Split segment
     let segment = utils.get_segment(track, segment_index);
+
     track.segments.push({  // new segment
         lat: segment.lat.slice(split_point),
         lon: segment.lon.slice(split_point),
         ele: segment.ele.slice(split_point),
         distance: segment.distance.slice(split_point),
-        segment_distance: segment.segment_distance.slice(split_point) - segment.segment_distance[split_point],
+        segment_distance: segment.segment_distance.slice(split_point).map(a => a + segment.segment_distance[split_point]),
         size: segment.size - split_point,
         index: segment_index + 1,
         name: segment.name + '_2part'

--- a/editor/views.py
+++ b/editor/views.py
@@ -44,10 +44,10 @@ def check_view(method, error_code):
             try:
                 return func(request, *args, **kwargs)
             except Exception as e:
-                print(f'Error in function: {func.__name__}')
-                print(f'Call: {func.__name__}({args}, {kwargs})')
-                print(traceback.format_exc())
-                logger.error(f'exception={e}, function={func.__name__}, {args=}, {kwargs=}')
+                msg = f'Error in function: {func.__name__}\n' + \
+                      f'Call: {func.__name__}({args}, {kwargs})\n' + \
+                      traceback.format_exc()
+                logger.error(msg)
                 return JsonResponse(
                     {'error': f'Unexpected error ({error_code}): {e}'},
                     status=error_code)

--- a/libs/constants.py
+++ b/libs/constants.py
@@ -31,7 +31,7 @@ class Constants:
     app_path = os.path.dirname(os.path.realpath(__file__))
 
     # OSM request options
-    version = "v0.2.1"
+    version = "v0.2.2"
     email = "alguerre@outlook.com"
     tool = "TrackEditor"
 

--- a/libs/track.py
+++ b/libs/track.py
@@ -509,6 +509,11 @@ class Track:
         self.size += 1
         self.last_segment_idx = max(self.df_track['segment'])
 
+        # Names management
+        self.segment_names.insert(index,
+                                  self.segment_names[index-1] + '_part2')
+        self.segment_names[index - 1] += '_part1'
+
     def change_order(self, new_order: dict):
         """
         Modify the segments order

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=alguerre
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=TrackEditorWeb
-sonar.projectVersion=0.2.1
+sonar.projectVersion=0.2.2
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=TrackApp,TrackEditorWeb,editor,libs

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -177,7 +177,9 @@ class TrackTest(TestCase):
         # Specific checks
         self.assertEqual(obj_track.df_track.segment.iloc[99], 1)
         self.assertEqual(obj_track.df_track.segment.iloc[100], 2)
-
+        self.assertListEqual(obj_track.segment_names,
+                             ['island_full.gpx_part1',
+                              'island_full.gpx_part2'])
         # Non-regression checks
         self.assertEqual(initial_total_distance, obj_track.df_track.distance.iloc[-1])
         self.assertEqual(initial_shape, obj_track.df_track.shape)
@@ -209,6 +211,11 @@ class TrackTest(TestCase):
         self.assertEqual(obj_track.df_track.segment.iloc[80], 3)
         self.assertEqual(obj_track.df_track.segment.iloc[120], 4)
         self.assertEqual(obj_track.df_track.segment.iloc[-1], 4)
+        self.assertListEqual(obj_track.segment_names,
+                             ['island_full.gpx_part1_part1',
+                              'island_full.gpx_part1_part2',
+                              'island_full.gpx_part2_part1',
+                              'island_full.gpx_part2_part2'])
 
         # Non-regression checks
         self.assertEqual(initial_total_distance, obj_track.df_track.distance.iloc[-1])


### PR DESCRIPTION
## Scope
A number of segments are raising when using the _split segment_ command: #125  #134 #135 #137 

## Tasks
**Bug #125**
Unable to reproduce

**Bug #134**
Unable to reproduce

**Bug #135**
- [x] Display error in ```load_track()```
- [x] Include new segment in names list 
- [x] Manual test 

**Bug #137**
- [x] Find origin
- [x] Insert the segment_distance for both parts of split segment
- [x] Improve the ```update_distance``` function to work when the first index segment is not 0
- [x] Manual test 

**General**
- [x] Test with static in S3